### PR TITLE
No longer download JSS Importer from Testing now that 1.0.2b3 is available in Master

### DIFF
--- a/autopkg_setup_for_jss.sh
+++ b/autopkg_setup_for_jss.sh
@@ -164,11 +164,12 @@ installJSSImporter() {
     sleep 1
     ${AUTOPKG} run -v JSSImporterBeta.install
 
-    # Very latest with STOP_IF_NO_JSS_UPLOAD key needs to be downloaded
-    echo
-    echo "### Downloading very latest JSSImporter.py"
-    JSSIMPORTER_LATEST="https://raw.githubusercontent.com/grahampugh/JSSImporter/testing/JSSImporter.py"
-    sudo /usr/bin/curl -L "${JSSIMPORTER_LATEST}" -o "/Library/AutoPkg/autopkglib/JSSImporter.py"
+    ## Very latest with STOP_IF_NO_JSS_UPLOAD key needs to be downloaded
+    #echo
+    #echo "### Downloading very latest JSSImporter.py"
+    #JSSIMPORTER_LATEST="https://raw.githubusercontent.com/grahampugh/JSSImporter/testing/JSSImporter.py"
+    #sudo /usr/bin/curl -L "${JSSIMPORTER_LATEST}" -o "/Library/AutoPkg/autopkglib/JSSImporter.py"
+    # ^- No longer need to download beta2 now that JSS Importer 1.0.2b3 is available in Master
 }
 
 


### PR DESCRIPTION
First up, thanks for making this script available, it has been very useful.

No stress at all if you want to sort this out in your own way, or if perhaps you want to keep this script downloading from your Testing branch, I just figured I would note this in my fork and offer it as PR at the same time.

Hopefully fairly self-explanatory, this comments out the last part of InstallJSSImporter() which was bringing down JSSImporter.py from your testing branch and sticking with the Autopkg install which should now be installing 1.0.2b3.

Cheers.